### PR TITLE
Prevent shell globbing for nmap --script argument

### DIFF
--- a/SMB.md
+++ b/SMB.md
@@ -17,7 +17,7 @@ if (parseInt(tp.frontmatter.current_port) != 445) {
 -%>
 #### Nmap
 ```nmap
-nmap -p<% tp.frontmatter.current_port %> --script smb-vuln-* <% tp.frontmatter.target_ip %>
+nmap -p<% tp.frontmatter.current_port %> --script "smb-vuln-*" <% tp.frontmatter.target_ip %>
 ```
 
 #### SMBClient


### PR DESCRIPTION
Previous state would not parse correctly in some configurations of bash and zsh.